### PR TITLE
Website Publishing Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ log
 
 # Temp files
 build
+cc

--- a/index.html
+++ b/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<a href="html/">You should start here.</a>
+</body>
+</html>

--- a/publish
+++ b/publish
@@ -1,0 +1,14 @@
+#!/bin/bash
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <hostname>" >&2
+    echo "  e.g. $0 chop.aaron.dyn.iweb.co.uk" >&2
+    exit 1
+fi
+i=$1
+rm -rf cc
+httrack -O cc http://$i/
+cd cc/$i
+git init
+git add .
+git commit -m 'Website'
+git push git@github.com:getchopchop/getchopchop.github.io master:master -f


### PR DESCRIPTION
This branch adds some automated scripting for updating the documentation at https://getchopchop.github.io/

Updating requires that you `brew install httrack` first, and then you can run:

```
./publish chop.aaron.dyn.iweb.co.uk
```

Substitute your own hostname, without any `http://` prefix, to build your own version of the documentation. The documentation will be built out of whichever branch you are on. GH pages only supports one branch for the documentation.
