### PR TITLE
Reverted Gulp from v4 to current release (v3.9.1)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,7 +75,8 @@ var gulp = require('gulp' ),
         uglify:             require( 'gulp-uglify' ),
         sourcemaps:         require( 'gulp-sourcemaps' ),
         svgSprite:          require('gulp-svg-sprite'),
-        path:               require( 'path' )
+        path:               require( 'path' ),
+        runSequence:        require( 'run-sequence' )
     };
 
 
@@ -195,7 +196,22 @@ gulp.task( 'clean', function( cb ) {
 // builds all assets, also has `--production` option to build production ready assets
 // =============================================
 
-gulp.task( 'build', gulp.series( 'clean', gulp.parallel( 'scss', 'js' ), 'img', 'svg-sprite', 'vendor', 'vendor-images', 'vendor-styles', 'vendor-scripts' ) );
+gulp.task( 'build', function( callback ) {
+    nodeModule.runSequence(
+        'clean',
+        [
+            'scss',
+            'js'
+        ],
+        'img',
+        'svg-sprite',
+        'vendor',
+        'vendor-images',
+        'vendor-styles',
+        'vendor-scripts',
+        callback
+    );
+} );
 
 
 // =============================================
@@ -204,11 +220,11 @@ gulp.task( 'build', gulp.series( 'clean', gulp.parallel( 'scss', 'js' ), 'img', 
 // =============================================
 
 gulp.task( 'watch', function() {
-    gulp.watch( project.sourceDirectory + '/' + project.stylesDirectory + '/**/*.scss', gulp.series( 'scss' ) );
-    gulp.watch( project.sourceDirectory + '/' + project.scriptsDirectory + '/**/*.js', gulp.series( 'js' ) );
-    gulp.watch( project.sourceDirectory + '/' + project.imagesDirectory + '/**/*', gulp.series( 'img' ) );
-    gulp.watch( project.sourceDirectory + '/' + project.iconsDirectory + '/**/*', gulp.series( 'svg-sprite' ) );
-    gulp.watch( project.sourceDirectory + '/' + project.vendorDirectory + '/**/*', gulp.series( 'vendor' ) );
+    gulp.watch( project.sourceDirectory + '/' + project.stylesDirectory + '/**/*.scss', [ 'scss' ] );
+    gulp.watch( project.sourceDirectory + '/' + project.scriptsDirectory + '/**/*.js',  [ 'js' ] );
+    gulp.watch( project.sourceDirectory + '/' + project.imagesDirectory + '/**/*',  [ 'img' ] );
+    gulp.watch( project.sourceDirectory + '/' + project.iconsDirectory + '/**/*',  [ 'svg-sprite' ] );
+    gulp.watch( project.sourceDirectory + '/' + project.vendorDirectory + '/**/*',  [ 'vendor' ] );
 } );
 
 
@@ -217,4 +233,9 @@ gulp.task( 'watch', function() {
 // runs build task, Runs watch tasks
 // =============================================
 
-gulp.task( 'default', gulp.series( 'build', 'watch' ) );
+gulp.task( 'default', function() {
+    nodeModule.runSequence(
+        'build',
+        'watch'
+    );
+} );

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/getchopchop/chopchop",
   "devDependencies": {
     "del": "^2.1.0",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "github:gulpjs/gulp",
     "gulp-autoprefixer": "^3.0.2",
     "gulp-changed": "^1.3.0",
     "gulp-clip-empty-files": "^0.1.1",
@@ -43,6 +43,7 @@
     "gulp-svg-sprite": "^1.3.1",
     "gulp-uglify": "^1.4.2",
     "gulp-util": "^3.0.6",
-    "jshint": "^2.8.0"
+    "jshint": "^2.8.0",
+    "run-sequence": "^1.2.2"
   }
 }


### PR DESCRIPTION
Reverted to using the current release of Gulp (v3.9.1) instead of the prerelease version (v4).

Need to give Gulpv4 a more in-depth look at a later stage and properly finish implementing. 
