### PR TITLE
Split SVG sprite into multiple files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,20 +37,13 @@ var option = {
     },
     svgSpriteConfig: {
         shape: {
-            dimension: {                // Set maximum dimensions
-                maxWidth: 32,
-                maxHeight: 32
-            },
-            dest: 'intermediate-svg'    // Keep the intermediate files
+            dest: 'svg'    // Keep the intermediate files
         },
         mode: {
-            view: {                     // Activate the «view» mode
-                bust: false,
-                render: {
-                    scss: true          // Activate Sass output (with default options)
-                }
-            },
-            symbol: true                // Activate the «symbol» mode
+            view: false,
+            symbol: {
+                sprite: 'sprite-symbol.svg'
+            }
         }
     }
 };
@@ -75,6 +68,7 @@ var gulp = require('gulp' ),
         uglify:             require( 'gulp-uglify' ),
         sourcemaps:         require( 'gulp-sourcemaps' ),
         svgSprite:          require('gulp-svg-sprite'),
+        fs:                 require( 'fs' ),
         path:               require( 'path' ),
         runSequence:        require( 'run-sequence' )
     };
@@ -88,6 +82,18 @@ var environment = {
     development: nodeModule.util.env.dev,
     production: nodeModule.util.env.production
 };
+
+
+// =============================================
+// Function: getFolders
+// =============================================
+
+function getFolders( directory ) {
+    return nodeModule.fs.readdirSync( directory )
+        .filter( function( file ) {
+            return nodeModule.fs.statSync( nodeModule.path.join( directory, file ) ).isDirectory();
+        } );
+}
 
 
 // =============================================
@@ -126,9 +132,13 @@ gulp.task('vendor-images', function() {
 // =============================================
 
 gulp.task( 'svg-sprite', function() {
-    return gulp.src( project.sourceDirectory + '/' + project.iconsDirectory + '/**/*.svg' )
-        .pipe( nodeModule.svgSprite( option.svgSpriteConfig ) )
-        .pipe( gulp.dest( project.distDirectory + '/' + project.iconsDirectory ) );
+    var folders = getFolders( project.sourceDirectory + '/' + project.iconsDirectory + '/' );
+
+    return folders.map( function( folder ) {
+        return gulp.src( project.sourceDirectory + '/' + project.iconsDirectory + '/' + folder + '/**/*.svg' )
+            .pipe( nodeModule.svgSprite( option.svgSpriteConfig ) )
+            .pipe( gulp.dest( project.distDirectory + '/' + project.iconsDirectory + '/' + folder + '/' ) );
+    } );
 } );
 
 

--- a/html/atom/icons/1-icon.php
+++ b/html/atom/icons/1-icon.php
@@ -4,5 +4,5 @@ Class: .icon
 */ ?>
 
 <p>
-    <?php printSvg('general--home'); ?>
+    <?php printSvg('general', 'home'); ?>
 </p>

--- a/html/atom/icons/2-small.php
+++ b/html/atom/icons/2-small.php
@@ -4,5 +4,5 @@ Class: .icon.icon--sm
 */ ?>
 
 <p>
-    <?php printSvg('general--home', 'icon--sm'); ?>
+    <?php printSvg('general', 'home', 'icon--sm'); ?>
 </p>

--- a/html/atom/icons/3-large.php
+++ b/html/atom/icons/3-large.php
@@ -4,5 +4,5 @@ Class: .icon.icon--lg
 */ ?>
 
 <p>
-    <?php printSvg('general--home', 'icon--lg'); ?>
+    <?php printSvg('general', 'home', 'icon--lg'); ?>
 </p>

--- a/html/atom/icons/4-social.php
+++ b/html/atom/icons/4-social.php
@@ -4,27 +4,27 @@ Title: Social Icons
 
 <ul class="u-list-unstyled u-list-inline">
     <li>
-        <?php printSvg('social--linkedin'); ?>
+        <?php printSvg('social', 'linkedin'); ?>
     </li>
     <li>
-        <?php printSvg('social--twitter'); ?>
+        <?php printSvg('social', 'twitter'); ?>
     </li>
     <li>
-        <?php printSvg('social--facebook'); ?>
+        <?php printSvg('social', 'facebook'); ?>
     </li>
     <li>
-        <?php printSvg('social--google-plus'); ?>
+        <?php printSvg('social', 'google-plus'); ?>
     </li>
     <li>
-        <?php printSvg('social--instagram'); ?>
+        <?php printSvg('social', 'instagram'); ?>
     </li>
     <li>
-        <?php printSvg('social--youtube'); ?>
+        <?php printSvg('social', 'youtube'); ?>
     </li>
     <li>
-        <?php printSvg('social--pinterest'); ?>
+        <?php printSvg('social', 'pinterest'); ?>
     </li>
     <li>
-        <?php printSvg('social--tumblr'); ?>
+        <?php printSvg('social', 'tumblr'); ?>
     </li>
 </ul>

--- a/html/atom/icons/5-common.php
+++ b/html/atom/icons/5-common.php
@@ -41,7 +41,7 @@ Title: Common Icons
         foreach($icons as $icon) :
     ?>
         <li>
-            <?php printSvg('general--' . $icon); ?>
+            <?php printSvg('general', $icon); ?>
         </li>
     <?php
         endforeach;

--- a/html/atom/icons/6-payment.php
+++ b/html/atom/icons/6-payment.php
@@ -3,67 +3,67 @@ Title: Payment Icons using images
 */ ?>
 
 <ul class="u-list-inline">
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--amazon.svg'); ?>" alt="Amazon" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--american-express.svg'); ?>" alt="America Express" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--braintree.svg'); ?>" alt="Braintree" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--cirrus.svg'); ?>" alt="Cirrus" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--direct-debit.svg'); ?>" alt="Direct Debit" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--ebay.svg'); ?>" alt="Ebay" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--jcb.svg'); ?>" alt="JCB" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--maestro.svg'); ?>" alt="Maestro" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--mastercard-securecode.svg'); ?>" alt="Mastercard Securecode" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--mastercard.svg'); ?>" alt="Mastercard" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--norton.svg'); ?>" alt="Norton" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--paypal.svg'); ?>" alt="Paypal" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--sage.svg'); ?>" alt="Sage" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--stripe.svg'); ?>" alt="Stripe" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--verified-by-visa.svg'); ?>" alt="Verified By Visa" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--visa-electron.svg'); ?>" alt="Visa Electron" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--visa.svg'); ?>" alt="Visa" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--western-union.svg'); ?>" alt="Western Union" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--color--worldpay.svg'); ?>" alt="WordPay" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--amazon.svg'); ?>" alt="Amazon" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--american-express.svg'); ?>" alt="America Express" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--braintree.svg'); ?>" alt="Braintree" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--cirrus.svg'); ?>" alt="Cirrus" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--direct-debit.svg'); ?>" alt="Direct Debit" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--ebay.svg'); ?>" alt="Ebay" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--jcb.svg'); ?>" alt="JCB" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--maestro.svg'); ?>" alt="Maestro" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--mastercard-securecode.svg'); ?>" alt="Mastercard Securecode" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--mastercard.svg'); ?>" alt="Mastercard" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--norton.svg'); ?>" alt="Norton" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--paypal.svg'); ?>" alt="Paypal" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--sage.svg'); ?>" alt="Sage" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--stripe.svg'); ?>" alt="Stripe" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--verified-by-visa.svg'); ?>" alt="Verified By Visa" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--visa-electron.svg'); ?>" alt="Visa Electron" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--visa.svg'); ?>" alt="Visa" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--western-union.svg'); ?>" alt="Western Union" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/color--worldpay.svg'); ?>" alt="WordPay" width="63" height="40" /></li>
 </ul>
 
 <ul class="u-list-inline">
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--amazon.svg'); ?>" alt="Amazon" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--american-express.svg'); ?>" alt="America Express" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--braintree.svg'); ?>" alt="Braintree" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--cirrus.svg'); ?>" alt="Cirrus" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--direct-debit.svg'); ?>" alt="Direct Debit" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--ebay.svg'); ?>" alt="Ebay" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--jcb.svg'); ?>" alt="JCB" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--maestro.svg'); ?>" alt="Maestro" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--mastercard-securecode.svg'); ?>" alt="Mastercard Securecode" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--mastercard.svg'); ?>" alt="Mastercard" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--norton.svg'); ?>" alt="Norton" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--paypal.svg'); ?>" alt="Paypal" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--sage.svg'); ?>" alt="Sage" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--stripe.svg'); ?>" alt="Stripe" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--verified-by-visa.svg'); ?>" alt="Verified By Visa" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--visa-electron.svg'); ?>" alt="Visa Electron" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--visa.svg'); ?>" alt="Visa" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--western-union.svg'); ?>" alt="Western Union" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--white--worldpay.svg'); ?>" alt="WordPay" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--amazon.svg'); ?>" alt="Amazon" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--american-express.svg'); ?>" alt="America Express" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--braintree.svg'); ?>" alt="Braintree" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--cirrus.svg'); ?>" alt="Cirrus" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--direct-debit.svg'); ?>" alt="Direct Debit" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--ebay.svg'); ?>" alt="Ebay" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--jcb.svg'); ?>" alt="JCB" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--maestro.svg'); ?>" alt="Maestro" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--mastercard-securecode.svg'); ?>" alt="Mastercard Securecode" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--mastercard.svg'); ?>" alt="Mastercard" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--norton.svg'); ?>" alt="Norton" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--paypal.svg'); ?>" alt="Paypal" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--sage.svg'); ?>" alt="Sage" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--stripe.svg'); ?>" alt="Stripe" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--verified-by-visa.svg'); ?>" alt="Verified By Visa" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--visa-electron.svg'); ?>" alt="Visa Electron" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--visa.svg'); ?>" alt="Visa" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--western-union.svg'); ?>" alt="Western Union" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/white--worldpay.svg'); ?>" alt="WordPay" width="63" height="40" /></li>
 </ul>
 
 <ul class="u-list-inline">
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--amazon.svg'); ?>" alt="Amazon" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--american-express.svg'); ?>" alt="America Express" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--braintree.svg'); ?>" alt="Braintree" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--cirrus.svg'); ?>" alt="Cirrus" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--direct-debit.svg'); ?>" alt="Direct Debit" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--ebay.svg'); ?>" alt="Ebay" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--jcb.svg'); ?>" alt="JCB" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--maestro.svg'); ?>" alt="Maestro" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--mastercard-securecode.svg'); ?>" alt="Mastercard Securecode" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--mastercard.svg'); ?>" alt="Mastercard" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--norton.svg'); ?>" alt="Norton" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--paypal.svg'); ?>" alt="Paypal" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--sage.svg'); ?>" alt="Sage" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--stripe.svg'); ?>" alt="Stripe" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--verified-by-visa.svg'); ?>" alt="Verified By Visa" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--visa-electron.svg'); ?>" alt="Visa Electron" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--visa.svg'); ?>" alt="Visa" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--western-union.svg'); ?>" alt="Western Union" width="63" height="40" /></li>
-    <li><img src="<?php echo getUrl('build/img/icons/intermediate-svg/payments--transparent--worldpay.svg'); ?>" alt="WordPay" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--amazon.svg'); ?>" alt="Amazon" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--american-express.svg'); ?>" alt="America Express" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--braintree.svg'); ?>" alt="Braintree" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--cirrus.svg'); ?>" alt="Cirrus" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--direct-debit.svg'); ?>" alt="Direct Debit" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--ebay.svg'); ?>" alt="Ebay" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--jcb.svg'); ?>" alt="JCB" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--maestro.svg'); ?>" alt="Maestro" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--mastercard-securecode.svg'); ?>" alt="Mastercard Securecode" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--mastercard.svg'); ?>" alt="Mastercard" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--norton.svg'); ?>" alt="Norton" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--paypal.svg'); ?>" alt="Paypal" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--sage.svg'); ?>" alt="Sage" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--stripe.svg'); ?>" alt="Stripe" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--verified-by-visa.svg'); ?>" alt="Verified By Visa" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--visa-electron.svg'); ?>" alt="Visa Electron" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--visa.svg'); ?>" alt="Visa" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--western-union.svg'); ?>" alt="Western Union" width="63" height="40" /></li>
+    <li><img src="<?php echo getUrl('build/img/icons/payments/svg/transparent--worldpay.svg'); ?>" alt="WordPay" width="63" height="40" /></li>
 </ul>

--- a/html/inc/functions.php
+++ b/html/inc/functions.php
@@ -35,9 +35,9 @@
         echo get($location, $options);
     }
 
-    function printSvg($hash, $class = '', $location = 'sprite.symbol.svg') {
+    function printSvg($folder = 'general', $hash, $class = '') {
         echo '<svg class="icon ' . $class . '">
-            <use xlink:href="' . getUrl('build/img/icons/symbol/svg/' . $location) . '#' . $hash  . '" />
+            <use xlink:href="' . getUrl('build/img/icons/' . $folder . '/symbol/sprite-symbol.svg') . '#' . $hash  . '" />
         </svg>';
     }
 
@@ -140,7 +140,7 @@
     }
 
     function title($title, $class, $description='') {
-	    return array(
+        return array(
             'title'=>$title,
             'class'=>$class,
             'description'=>$description

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/getchopchop/chopchop",
   "devDependencies": {
     "del": "^2.1.0",
+    "fs": "0.0.2",
     "gulp": "github:gulpjs/gulp",
     "gulp-autoprefixer": "^3.0.2",
     "gulp-changed": "^1.3.0",
@@ -44,6 +45,7 @@
     "gulp-uglify": "^1.4.2",
     "gulp-util": "^3.0.6",
     "jshint": "^2.8.0",
+    "path": "^0.12.7",
     "run-sequence": "^1.2.2"
   }
 }


### PR DESCRIPTION
Generates svg sprites per top level directory within img/icons instead of a single sprite. Helps prevent file sizes getting too large.
- Updated Gulpfile to run svg-sprite task per top level directory within img/icons
- Edited the printSvg function to work with the new directory structure

Resolves: issue #18
